### PR TITLE
Add React Native iframe example

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { WebView } from 'react-native-webview';
+
+export default function App() {
+  const html = `\n    <!DOCTYPE html>\n    <html>\n      <body style="margin:0;padding:0;">\n        <iframe src="https://example.com" width="100%" height="100%" style="border:none;"></iframe>\n      </body>\n    </html>`;
+
+  return (
+    <View style={styles.container}>
+      <WebView originWhitelist={["*"]} source={{ html }} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1
+  }
+});

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# codex_test
+# ios-iframe-app
+
+This repository contains a minimal React Native example for iOS that displays an iframe within a `WebView`.
+
+## Running the app
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+2. Run the project using the React Native CLI or Expo tooling of your choice.
+
+The core app is defined in `App.js`.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ios-iframe-app",
+  "version": "1.0.0",
+  "private": true,
+  "main": "App.js",
+  "dependencies": {
+    "react": "18.2.0",
+    "react-native": "0.72.3",
+    "react-native-webview": "11.29.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add React Native package configuration
- create `App.js` with `WebView` wrapper for an iframe
- document how to run the example

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68475e14d0c083219b6055c871e67ce8